### PR TITLE
Reintroduce getkey()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ CallHistory.storedata*
 
 # executables
 callhistory
+osx-callhistory-decryptor
 cmd/msgtime/msgtime

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ os:
   - windows
 
 go:
-  - "1.11"     # oldest supported
-  - "1.13.x"  # latest
+  - "1.15.x"  # latest
 
 before_install:
   - go get ${gobuild_args} ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.15
+LABEL maintainer="github.com/rusq"
+
+COPY . /src
+
+WORKDIR /src
+
+RUN go test ./...
+RUN go build

--- a/README.md
+++ b/README.md
@@ -24,6 +24,39 @@ Downloads are available on [Releases page][5].
 ## Usage
 Start the program with `-h` command line flag to see the usage help.  Available options will differ depending on the OS the program being started on.
 
+## MacOS
+
+Open the Terminal.app. ([How?][3])
+
+1. Get the copy of the `CallHistory.storedata` from source OS X machine.  The file is stored in this location:
+        
+        "$HOME/Library/Application Support/CallHistoryDB/CallHistory.storedata"
+
+    with `$HOME` being the user's home directory.
+
+    Copy it to the same directory where you've unpacked the 'callhistory':
+
+       $ cp "$HOME/Library/Application Support/CallHistoryDB/CallHistory.storedata" .
+
+2. Start the callhistory decryptor:
+
+        $ ./callhistory
+
+3. You will be prompted for your user's logon password, this allows the program to fetch the callhistory key from the OS X keychain.  You can also provide the call history key manually using the `-k` command line flag.  Example:
+
+        $ ./callhistory -k YSBzZWNyZXQga2V5IDEyCg==
+
+4. The output will be printed onto the terminal by default.  You can specify an output file by providing the `-o` command line flag:
+
+        $ ./callhistory -o output.csv
+
+If the database file is called differently than `CallHistory.storedata`, then use `-f` command line flag to provide the filename:
+
+        $ callhistory -o output.csv -f Calls.db
+
+
+## Linux, Windows, etc.
+
 You will still to obtain the database and the encryption key from the MacOS system.
 
 1. Get the copy of the `CallHistory.storedata` from source OS X machine.  The file is stored in this location:

--- a/callhistory.go
+++ b/callhistory.go
@@ -28,9 +28,7 @@ import (
 )
 
 var (
-	envKey = os.Getenv("KEY")
-
-	strKey         = flag.String("k", envKey, "Base64 key value from OS X keychain.")
+	strKey         = flag.String("k", os.Getenv("KEY"), "Base64 key value from OS X keychain, on macOS may be omitted.")
 	filename       = flag.String("f", "CallHistory.storedata", "filename with call data. Get it from:\n"+os.Getenv("HOME")+"/Library/Application Support/CallHistoryDB/\n")
 	outputFilename = flag.String("o", "", "output csv filename.  If not specified, result is output to stdout")
 	versionOnly    = flag.Bool("v", false, "print version and quit")
@@ -52,7 +50,7 @@ func main() {
 		return
 	}
 
-	key, err := historydecryptor.DecodeB64Key([]byte(*strKey))
+	key, err := historydecryptor.GetByteKey(*strKey)
 	if err != nil {
 		log.Fatalf("%s: make sure you have supplied the key via -k or KEY env variable", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/rusq/osx-callhistory-decryptor
 
 go 1.13
 
-require github.com/mattn/go-sqlite3 v1.11.0
+require (
+	github.com/keybase/go-keychain v0.0.0-20201121013009-976c83ec27a6
+	github.com/mattn/go-sqlite3 v1.11.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,18 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/keybase/go-keychain v0.0.0-20201121013009-976c83ec27a6 h1:Mj0fhP9dzHKPijsmli/XbXMDKe1/KWy5xKci8e3nmBg=
+github.com/keybase/go-keychain v0.0.0-20201121013009-976c83ec27a6/go.mod h1:N83iQ9rnnzi2KZuTu+0xBcD1JNWn1jSN140ggAF7HeE=
+github.com/keybase/go.dbus v0.0.0-20200324223359-a94be52c0b03/go.mod h1:a8clEhrrGV/d76/f9r2I41BwANMihfZYV9C223vaxqE=
 github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/historydecryptor/getkey.go
+++ b/historydecryptor/getkey.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetByteKey(keyStr string) ([]byte, error) {
-	if len(strKey) == 0 {
+	if len(keyStr) == 0 {
 		return nil, fmt.Errorf("Use -k <key> parameter to supply the key.")
 	}
 	key, err := DecodeB64Key([]byte(strKey))

--- a/historydecryptor/getkey.go
+++ b/historydecryptor/getkey.go
@@ -1,0 +1,18 @@
+// +build !darwin
+
+package historydecryptor
+
+import (
+	"fmt"
+)
+
+func GetByteKey(keyStr string) ([]byte, error) {
+	if len(strKey) == 0 {
+		return nil, fmt.Errorf("Use -k <key> parameter to supply the key.")
+	}
+	key, err := DecodeB64Key([]byte(strKey))
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}

--- a/historydecryptor/getkey.go
+++ b/historydecryptor/getkey.go
@@ -10,7 +10,7 @@ func GetByteKey(keyStr string) ([]byte, error) {
 	if len(keyStr) == 0 {
 		return nil, fmt.Errorf("Use -k <key> parameter to supply the key.")
 	}
-	key, err := DecodeB64Key([]byte(strKey))
+	key, err := DecodeB64Key([]byte(keyStr))
 	if err != nil {
 		return nil, err
 	}

--- a/historydecryptor/getkey_darwin.go
+++ b/historydecryptor/getkey_darwin.go
@@ -1,0 +1,38 @@
+// +build darwin
+
+package historydecryptor
+
+import (
+	"fmt"
+
+	keychain "github.com/keybase/go-keychain"
+)
+
+// GetByteKey decodes the key.  If keyStr is not set, it attempts to get the key
+// from the keychain.  If it is set - it's better be a base64 encoded key!
+func GetByteKey(keyStr string) (key []byte, err error) {
+	if len(keyStr) == 0 {
+		key, err = getCallHistoryPwd(true)
+	} else {
+		key, err = DecodeB64Key([]byte(keyStr))
+	}
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func getCallHistoryPwd(interactive bool) ([]byte, error) {
+	if interactive {
+		fmt.Printf("Enter your account password to access keychain when prompted...\n")
+	}
+	passwd, err := keychain.GetGenericPassword("Call History User Data Key", "", "Call History User Data Key", "")
+	if err != nil {
+		return nil, err
+	}
+	key, err := DecodeB64Key(passwd)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}

--- a/historydecryptor/getkey_darwin_test.go
+++ b/historydecryptor/getkey_darwin_test.go
@@ -1,0 +1,35 @@
+// +build darwin
+
+package historydecryptor
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_getByteKey(t *testing.T) {
+	type args struct {
+		keyStr string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{"valid base64", args{keyStr: "VGVzdCBrZXkK"}, []byte("Test key\n"), false},
+		{"invalid base64", args{"xxx"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetByteKey(tt.args.keyStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getByteKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getByteKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/historydecryptor/getkey_test.go
+++ b/historydecryptor/getkey_test.go
@@ -1,0 +1,36 @@
+// +build !darwin
+
+package historydecryptor
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_getByteKey(t *testing.T) {
+	type args struct {
+		keyStr string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{"case1", args{keyStr: "VGVzdCBrZXkK"}, []byte("Test key\n"), false},
+		{"Invalid base64", args{"xxx"}, nil, true},
+		{"Empty key", args{""}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetByteKey(tt.args.keyStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getByteKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getByteKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Looks like go-keychain was updated to support the `GetGenericPassword` again.