### PR TITLE
Time fmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ CallHistory.storedata*
 callhistory
 osx-callhistory-decryptor
 cmd/msgtime/msgtime
+
+# IDE
+.idea

--- a/callhistory.go
+++ b/callhistory.go
@@ -32,6 +32,7 @@ var (
 	filename       = flag.String("f", "CallHistory.storedata", "filename with call data. Get it from:\n"+os.Getenv("HOME")+"/Library/Application Support/CallHistoryDB/\n")
 	outputFilename = flag.String("o", "", "output csv filename.  If not specified, result is output to stdout")
 	versionOnly    = flag.Bool("v", false, "print version and quit")
+	timeFormat     = flag.String("time-format", historydecryptor.DefTimeFmt, "CSV output time `format`")
 
 	build = "v.0.0-development"
 )
@@ -66,7 +67,7 @@ func main() {
 
 	log.Printf("*** filename: %s\n", *filename)
 
-	numRecords, err := historydecryptor.DecipherHistory(*filename, key, outFile)
+	numRecords, err := historydecryptor.DecipherHistory(*filename, key, outFile, historydecryptor.OptTimeFormat(*timeFormat))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/historydecryptor/getkey_darwin.go
+++ b/historydecryptor/getkey_darwin.go
@@ -5,7 +5,7 @@ package historydecryptor
 import (
 	"fmt"
 
-	keychain "github.com/keybase/go-keychain"
+	"github.com/keybase/go-keychain"
 )
 
 // GetByteKey decodes the key.  If keyStr is not set, it attempts to get the key

--- a/historydecryptor/historydecryptor.go
+++ b/historydecryptor/historydecryptor.go
@@ -41,12 +41,17 @@ const (
 	DefTimeFmt = "2006-01-02 15:04:05Z07:00"
 )
 
+// outputSettings stores the output settings for the CSV.
 type outputSettings struct {
 	timeFmt string
 }
 
+// Option is the function signature that allows to modify the CSV output
+// settings.
 type Option func(*outputSettings)
 
+// OptTimeFormat specifies the time/date output format. (See time package for
+// time format specification).
 func OptTimeFormat(f string) Option {
 	return func(s *outputSettings) {
 		if f == "" {

--- a/historydecryptor/historydecryptor.go
+++ b/historydecryptor/historydecryptor.go
@@ -37,11 +37,35 @@ const (
 			ZADDRESS
 		from ZCALLRECORD
 		order by ZDATE`
+
+	DefTimeFmt = "2006-01-02 15:04:05Z07:00"
 )
+
+type outputSettings struct {
+	timeFmt string
+}
+
+type Option func(*outputSettings)
+
+func OptTimeFormat(f string) Option {
+	return func(s *outputSettings) {
+		if f == "" {
+			s.timeFmt = DefTimeFmt
+		}
+		s.timeFmt = f
+	}
+}
 
 // DecipherHistory opens the database and writes CSV output to output
 // returns number of rows processed or an error (if any)
-func DecipherHistory(database string, key []byte, output io.Writer) (int, error) {
+func DecipherHistory(database string, key []byte, output io.Writer, opts ...Option) (int, error) {
+	var s = outputSettings{
+		timeFmt: DefTimeFmt,
+	}
+	for _, opt := range opts {
+		opt(&s)
+	}
+
 	db, err := sql.Open("sqlite3", database)
 	if err != nil {
 		return 0, err
@@ -59,7 +83,6 @@ func DecipherHistory(database string, key []byte, output io.Writer) (int, error)
 	csvOut.Write([]string{"Date", "Answered?", "Outgoing?", "Type", "Country", "Number/Address"})
 
 	numRecords := 0
-
 	for rows.Next() {
 		var (
 			callOffset float64
@@ -80,7 +103,7 @@ func DecipherHistory(database string, key []byte, output io.Writer) (int, error)
 		if err != nil {
 			return 0, err
 		}
-		csvOut.Write([]string{callTime.Format("2006-01-02 15:04:05Z0700"),
+		csvOut.Write([]string{callTime.Format(s.timeFmt),
 			answered, originated, calltype, country.String, string(address)})
 
 		numRecords++

--- a/historydecryptor/historydecryptor_test.go
+++ b/historydecryptor/historydecryptor_test.go
@@ -74,12 +74,26 @@ const (
 2015-05-19 05:19:12Z,true,false,CellPhone,nz,
 2015-06-10 02:56:01Z,true,false,CellPhone,nz,
 `
+
+	noTZdata = `Date,Answered?,Outgoing?,Type,Country,Number/Address
+2014-09-30 07:42,true,false,CellPhone,ru,
+2014-10-19 14:32,true,false,CellPhone,ru,
+2014-11-11 13:39,false,true,CellPhone,ru,
+2014-11-13 17:01,true,false,CellPhone,ru,
+2014-11-17 07:43,false,false,CellPhone,ru,
+2014-11-21 08:32,false,true,CellPhone,ru,
+2014-11-21 09:31,true,false,CellPhone,ru,
+2014-11-21 17:23,false,true,CellPhone,ru,
+2015-05-19 05:19,true,false,CellPhone,nz,
+2015-06-10 02:56,true,false,CellPhone,nz,
+`
 )
 
 func TestDecipherHistory(t *testing.T) {
 	type args struct {
 		database string
 		key      []byte
+		opts     []Option
 	}
 	tests := []struct {
 		name       string
@@ -88,12 +102,13 @@ func TestDecipherHistory(t *testing.T) {
 		wantOutput string
 		wantErr    bool
 	}{
-		{"Parsing sample db", args{"sample_db/sample.storedata", []byte{0, 0}}, 10, sampledbData, false},
+		{"Parsing sample db", args{"sample_db/sample.storedata", []byte{0, 0}, nil}, 10, sampledbData, false},
+		{"different time format", args{"sample_db/sample.storedata", []byte{0, 0}, []Option{OptTimeFormat("2006-01-02 15:04")}}, 10, noTZdata, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			output := &bytes.Buffer{}
-			got, err := DecipherHistory(tt.args.database, tt.args.key, output)
+			got, err := DecipherHistory(tt.args.database, tt.args.key, output, tt.args.opts...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DecipherHistory() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Fixes #5:
* introduce new command line parameter `-time-format` that allows to specify the required time/date format in the CSV output.  Format is described in [Golang time package doc](https://golang.org/pkg/time/#pkg-constants)